### PR TITLE
Create array in-place without an intermediate Vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,11 +153,13 @@ where
             cnt_filled += 1;
         };
         if let Some(err) = err {
-            for elem in std::array::IntoIter::new(arr).take(cnt_filled) {
-                // Safety: `assume_init()` is sound because we did initialize CNT_FILLED
-                // elements. We call it to drop the deserialized values.
-                unsafe {
-                    elem.assume_init();
+            if std::mem::needs_drop::<T>() {
+                for elem in std::array::IntoIter::new(arr).take(cnt_filled) {
+                    // Safety: `assume_init()` is sound because we did initialize CNT_FILLED
+                    // elements. We call it to drop the deserialized values.
+                    unsafe {
+                        elem.assume_init();
+                    }
                 }
             }
             return Err(err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ use serde::{
     de::{self, Deserialize, Deserializer, SeqAccess, Visitor},
     ser::{Serialize, SerializeTuple, Serializer},
 };
-use std::{fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, mem::MaybeUninit};
 
 /// Serialize const generic or arbitrarily-large arrays
 ///
@@ -113,89 +113,6 @@ struct ArrayVisitor<T, const N: usize> {
     _marker: PhantomData<T>,
 }
 
-#[cfg(inhibit_unsafe)]
-fn into_array<T, E: serde::de::Error, const N: usize>(
-    mut source: impl Iterator<Item = Result<T, E>>,
-) -> Result<[T; N], E> {
-    use std::convert::TryInto;
-
-    // Build a temporary container to hold our data as we deserialize it
-    // We can't rely on a Default<T> implementation, so we can't use an array here
-    let mut arr = Vec::with_capacity(N);
-
-    while let Some(val) = source.next() {
-        arr.push(val?);
-    }
-
-    // We can convert a Vec into an array via TryInto, which will fail if the length of the Vec
-    // doesn't match that of the array.
-    match arr.try_into() {
-        Ok(arr) => Ok(arr),
-
-        Err(arr) => Err(de::Error::invalid_length(
-            arr.len(),
-            &format!("an array of size {}", N).as_str(),
-        )),
-    }
-}
-
-#[cfg(not(inhibit_unsafe))]
-fn into_array<T, E: serde::de::Error, const N: usize>(
-    mut source: impl Iterator<Item = Result<T, E>>,
-) -> Result<[T; N], E> {
-    use std::mem::MaybeUninit;
-
-    // Safety: `assume_init` is sound because the type we are claiming to have
-    // initialized here is a bunch of `MaybeUninit`s, which do not require
-    // initialization.
-    let mut arr: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
-
-    // Iterate over the array and fill the elemenets with the ones obtained from
-    // `seq`.
-    let mut place_iter = arr.iter_mut();
-    let mut cnt_filled = 0;
-    let err = loop {
-        match (source.next(), place_iter.next()) {
-            (Some(Ok(val)), Some(place)) => *place = MaybeUninit::new(val),
-            // no error, we're done
-            (None, None) => break None,
-            // error from serde, propagate it
-            (Some(Err(e)), _) => break Some(e),
-            // lengths do not match, report invalid_length
-            (None, Some(_)) | (Some(Ok(_)), None) => {
-                break Some(de::Error::invalid_length(
-                    cnt_filled,
-                    &format!("an array of size {}", N).as_str(),
-                ))
-            }
-        }
-        cnt_filled += 1;
-    };
-    if let Some(err) = err {
-        if std::mem::needs_drop::<T>() {
-            for elem in std::array::IntoIter::new(arr).take(cnt_filled) {
-                // Safety: `assume_init()` is sound because we did initialize CNT_FILLED
-                // elements. We call it to drop the deserialized values.
-                unsafe {
-                    elem.assume_init();
-                }
-            }
-        }
-        return Err(err);
-    }
-
-    // Safety: everything is initialized and we are ready to transmute to the
-    // initialized array type.
-
-    // See https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
-    //let ret = unsafe { std::mem::transmute::<_, [T; N]>(arr) };
-
-    let ret = unsafe { std::mem::transmute_copy(&arr) };
-    std::mem::forget(arr);
-
-    Ok(ret)
-}
-
 impl<'de, T, const N: usize> Visitor<'de> for ArrayVisitor<T, N>
 where
     T: Deserialize<'de>,
@@ -212,7 +129,52 @@ where
     where
         A: SeqAccess<'de>,
     {
-        into_array(std::iter::from_fn(move || seq.next_element().transpose()))
+        // Safety: `assume_init` is sound because the type we are claiming to have
+        // initialized here is a bunch of `MaybeUninit`s, which do not require
+        // initialization.
+        let mut arr: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+
+        // Iterate over the array and fill the elemenets with the ones obtained from
+        // `seq`.
+        let mut place_iter = arr.iter_mut();
+        let mut cnt_filled = 0;
+        let err = loop {
+            match (seq.next_element(), place_iter.next()) {
+                (Ok(Some(val)), Some(place)) => *place = MaybeUninit::new(val),
+                // no error, we're done
+                (Ok(None), None) => break None,
+                // error from serde, propagate it
+                (Err(e), _) => break Some(e),
+                // lengths do not match, report invalid_length
+                (Ok(None), Some(_)) | (Ok(Some(_)), None) => {
+                    break Some(de::Error::invalid_length(cnt_filled, &self))
+                }
+            }
+            cnt_filled += 1;
+        };
+        if let Some(err) = err {
+            if std::mem::needs_drop::<T>() {
+                for elem in std::array::IntoIter::new(arr).take(cnt_filled) {
+                    // Safety: `assume_init()` is sound because we did initialize CNT_FILLED
+                    // elements. We call it to drop the deserialized values.
+                    unsafe {
+                        elem.assume_init();
+                    }
+                }
+            }
+            return Err(err);
+        }
+
+        // Safety: everything is initialized and we are ready to transmute to the
+        // initialized array type.
+
+        // See https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
+        //let ret = unsafe { std::mem::transmute::<_, [T; N]>(arr) };
+
+        let ret = unsafe { std::mem::transmute_copy(&arr) };
+        std::mem::forget(arr);
+
+        Ok(ret)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ use serde::{
     de::{self, Deserialize, Deserializer, SeqAccess, Visitor},
     ser::{Serialize, SerializeTuple, Serializer},
 };
-use std::{convert::TryInto, fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, mem::MaybeUninit};
 
 /// Serialize const generic or arbitrarily-large arrays
 ///
@@ -129,20 +129,50 @@ where
     where
         A: SeqAccess<'de>,
     {
-        // Build a temporary container to hold our data as we deserialize it
-        // We can't rely on a Default<T> implementation, so we can't use an array here
-        let mut arr = Vec::with_capacity(N);
+        // Safety: `assume_init` is sound because the type we are claiming to have
+        // initialized here is a bunch of `MaybeUninit`s, which do not require
+        // initialization.
+        let mut arr: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
 
-        while let Some(val) = seq.next_element()? {
-            arr.push(val);
+        // Iterate over the array and fill the elemenets with the ones obtained from
+        // `seq`.
+        let mut place_iter = arr.iter_mut();
+        let mut cnt_filled = 0;
+        let err = loop {
+            match (seq.next_element(), place_iter.next()) {
+                (Ok(Some(val)), Some(place)) => *place = MaybeUninit::new(val),
+                // no error, we're done
+                (Ok(None), None) => break None,
+                // error from serde, propagate it
+                (Err(e), _) => break Some(e),
+                // lengths do not match, report invalid_length
+                (Ok(None), Some(_)) | (Ok(Some(_)), None) => {
+                    break Some(de::Error::invalid_length(cnt_filled, &self))
+                }
+            }
+            cnt_filled += 1;
+        };
+        if let Some(err) = err {
+            for elem in std::array::IntoIter::new(arr).take(cnt_filled) {
+                // Safety: `assume_init()` is sound because we did initialize CNT_FILLED
+                // elements. We call it to drop the deserialized values.
+                unsafe {
+                    elem.assume_init();
+                }
+            }
+            return Err(err);
         }
 
-        // We can convert a Vec into an array via TryInto, which will fail if the length of the Vec
-        // doesn't match that of the array.
-        match arr.try_into() {
-            Ok(arr) => Ok(arr),
-            Err(arr) => Err(de::Error::invalid_length(arr.len(), &self)),
-        }
+        // Safety: everything is initialized and we are ready to transmute to the
+        // initialized array type.
+
+        // See https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
+        //let ret = unsafe { std::mem::transmute::<_, [T; N]>(arr) };
+
+        let ret = unsafe { std::mem::transmute_copy(&arr) };
+        std::mem::forget(arr);
+
+        Ok(ret)
     }
 }
 


### PR DESCRIPTION
Here is a commit that should speed up deserialization by avoiding the intermediate allocation.

Although unsafe appears to be complex compared to the original code, creating a vector for each array might represent a significant performance hit, especially in code bases with many small arrays. (Generics are often used to create small arrays whose sizes are e.g. 2 or 3 to represent two- or three-dimensional vectors.)