### PR TITLE
Updated crate for no-std capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_arrays"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Travis Veazey <travisvz@gmail.com>"]
 edition = "2018"
 resolver = "2" # New resolver keeps the dev-dependencies features separate
@@ -11,8 +11,14 @@ keywords = ["serde", "serialization", "const-generics"]
 categories = ["encoding"]
 exclude = ["/.github/*"]
 
+[features]
+default = ["std"]
+std = []
+no-std = ["heapless"]
+
 [dependencies]
-serde = { version = "1.0" }
+serde = { version = "1.0", default-features = false }
+heapless = { version = "0.7", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/tests/common/nested.rs
+++ b/tests/common/nested.rs
@@ -7,6 +7,9 @@
 
 use serde::Serialize;
 
+#[cfg(not(feature = "std"))]
+use heapless::Vec;
+
 #[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct NestedArray<const N: usize> {
     #[serde(with = "serde_arrays")]
@@ -19,8 +22,16 @@ pub struct GenericNestedArray<const N: usize, const M: usize> {
     pub arr: [[u32; N]; M],
 }
 
+#[cfg(feature = "std")]
 #[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct VecArray<const N: usize> {
     #[serde(with = "serde_arrays")]
     pub arr: Vec<[u32; N]>,
+}
+
+#[cfg(not(feature = "std"))]
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct VecArray<const N: usize, const M: usize> {
+    #[serde(with = "serde_arrays")]
+    pub arr: Vec<[u32; N], M>,
 }

--- a/tests/serialize_nested.rs
+++ b/tests/serialize_nested.rs
@@ -8,13 +8,38 @@
 mod common;
 use common::nested::*;
 
+#[cfg(not(feature = "std"))]
+use heapless::Vec;
+
 #[test]
+#[cfg(feature = "std")]
 fn serialize_nested_array() {
     let nested = NestedArray { arr: [[1; 3]; 2] };
     let generic = GenericNestedArray { arr: [[1; 3]; 2] };
     let vecced = VecArray {
         arr: vec![[1; 3]; 2],
     };
+
+    let j_nested = serde_json::to_string(&nested).unwrap();
+    let j_generic = serde_json::to_string(&generic).unwrap();
+    let j_vecced = serde_json::to_string(&vecced).unwrap();
+
+    let json = "{\"arr\":[[1,1,1],[1,1,1]]}";
+    assert_eq!(json, &j_nested);
+    assert_eq!(json, &j_generic);
+    assert_eq!(json, &j_vecced);
+}
+
+#[test]
+#[cfg(not(feature = "std"))]
+fn serialize_nested_array_no_std() {
+    let nested = NestedArray { arr: [[1; 3]; 2] };
+    let generic = GenericNestedArray { arr: [[1; 3]; 2] };
+
+    let mut arr = Vec::<[u32; 3], 2>::new();
+    arr.push([1; 3]).unwrap();
+    arr.push([1; 3]).unwrap();
+    let vecced = VecArray { arr };
 
     let j_nested = serde_json::to_string(&nested).unwrap();
     let j_generic = serde_json::to_string(&generic).unwrap();


### PR DESCRIPTION
Changed:
* Defaults features to false for serde for no-std
* std enable by default
* up-rev to 0.1.1
* Fixed error in documentation on no-std build
* Using core instead of std

Added:
* Implementation of Serializable for Heapless::Vec<[T;N],M>
* Heapless::Vec for no-std
* serialize_nested_array_no_std test
* VecArray with Heapless::Vec<[u32; N], M> definition